### PR TITLE
Let composer install newes 6.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This Skeleton comes pre-installed with following features:
 
 **Create a new Project**
 ```
-composer create-project dpfaffenbauer/pimcore-skeleton:6.0
+composer create-project dpfaffenbauer/pimcore-skeleton:^6.0
 ```
 
 **Start docker**


### PR DESCRIPTION
Using 6.0 pins compser to 6.0.0 version of this skeleton which is buggy. Using ^6.0 allows pimcore to go for 6.0.1.